### PR TITLE
Enable Scrolling

### DIFF
--- a/lib/rodal.css
+++ b/lib/rodal.css
@@ -1,7 +1,7 @@
 /* -- container -- */
 .rodal,
 .rodal-mask {
-    top: 15vh;
+    top: 0;
     left: 0;
     width: 100%;
     height: 100%;

--- a/lib/rodal.css
+++ b/lib/rodal.css
@@ -7,6 +7,7 @@
     height: 100%;
     z-index: 100;
     position: absolute;
+    overflow-y: scroll;
 }
 
 .rodal-dialog:focus {

--- a/lib/rodal.js
+++ b/lib/rodal.js
@@ -183,13 +183,13 @@ Rodal.propTypes = {
     onAnimationEnd: _propTypes2.default.func
 };
 Rodal.defaultProps = {
-    width: undefined,
-    height: undefined,
+    width: 400,
+    height: 240,
     measure: 'px',
     visible: false,
     showMask: true,
     closeOnEsc: false,
-    closeMaskOnClick: true,
+    closeMaskOnClick: false,
     showCloseButton: true,
     animation: 'zoom',
     enterAnimation: '',

--- a/src/rodal.js
+++ b/src/rodal.js
@@ -60,7 +60,7 @@ class Rodal extends React.Component {
         visible          : false,
         showMask         : true,
         closeOnEsc       : false,
-        closeMaskOnClick : true,
+        closeMaskOnClick : false,
         showCloseButton  : true,
         animation        : 'zoom',
         enterAnimation   : '',


### PR DESCRIPTION
Permet de scroller l'overflow des modals
Par défaut, on ne ferme pas la modal en cliquant dedans