### PR TITLE
Add zIndex to Dialog

### DIFF
--- a/lib/rodal.css
+++ b/lib/rodal.css
@@ -10,6 +10,11 @@
     overflow-y: scroll;
 }
 
+.rodal-dialog {
+    position: relative;
+    z-index: 101;
+}
+
 .rodal-dialog:focus {
     outline: none;
 }


### PR DESCRIPTION
Permet le clic sur les éléments qui étaient auparavant "bloqués" par le masque (z-index de 100)